### PR TITLE
remove CI=true

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,6 @@ ENV PATH /app/node_modules/.bin:$PATH
 # install app dependencies
 COPY package.json ./
 COPY package-lock.json ./
-# when running a single react container the process exits while starting 
-# development server but setting CI to true resolves the issue. 
-# Source - https://github.com/facebook/create-react-app/issues/8688#issuecomment-602084087
-RUN CI=true
 RUN npm install --silent
 
 # add app


### PR DESCRIPTION
Instead of `CI=true` in the dockerfile just run the docker command with `-it` flag. example: `docker run -it -p PORT:PORT image`